### PR TITLE
feat(nix): add configurable host key copying for nixos-anywhere

### DIFF
--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -234,6 +234,7 @@ pub async fn run(hive: Hive, opts: Opts) -> NaviResult<()> {
             opts.unlock,
             Some(final_nodes),
             None,
+            Some(&prov_config.kind),
         )
         .await?;
     }

--- a/src/command/provision.rs
+++ b/src/command/provision.rs
@@ -376,6 +376,7 @@ async fn run_terranix_provisioner(
                     opts.unlock,
                     Some(relevant_nodes),
                     None,
+                    Some(&crate::nix::ProvisionerType::Terranix),
                 )
                 .await?;
             }
@@ -502,6 +503,7 @@ async fn run_bare_metal_provisioner(
                     opts.unlock,
                     Some(node_names),
                     opts.initial_password.as_deref(),
+                    Some(&crate::nix::ProvisionerType::BareMetal),
                 )
                 .await?;
             }

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -251,6 +251,24 @@ pub struct ProvisionerConfig {
     pub derive: Vec<String>,
 }
 
+/// Controls whether nixos-anywhere copies SSH host keys from the installer
+/// to the target system. `Auto` enables it for bare-metal provisioners
+/// (where host keys won't exist on the fresh install), `Always` forces it
+/// on, and `Never` disables it.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CopyHostKeys {
+    Auto,
+    Always,
+    Never,
+}
+
+impl Default for CopyHostKeys {
+    fn default() -> Self {
+        CopyHostKeys::Auto
+    }
+}
+
 #[derive(Debug, Clone, Validate, Deserialize, Serialize)]
 pub struct NixosAnywhereConfig {
     pub enable: bool,
@@ -264,6 +282,8 @@ pub struct NixosAnywhereConfig {
     pub download_kexec_locally: bool,
     #[serde(rename = "kexecUrlTemplate", default)]
     pub kexec_url_template: Option<String>,
+    #[serde(rename = "copyHostKeys", default)]
+    pub copy_host_keys: CopyHostKeys,
 }
 
 #[derive(Debug, Clone, Validate, Deserialize, Serialize)]

--- a/src/nix/nixos_anywhere.rs
+++ b/src/nix/nixos_anywhere.rs
@@ -9,7 +9,8 @@ use tokio::time::sleep;
 
 use crate::error::{NaviError, NaviResult};
 use crate::nix::{
-    deployment::TargetNode, hive::Hive, NixosAnywhereConfig, NodeName, Ssh,
+    deployment::TargetNode, hive::Hive, CopyHostKeys, NixosAnywhereConfig,
+    NodeName, ProvisionerType, Ssh,
 };
 use crate::util::{CommandExt, CommandExecution};
 
@@ -21,6 +22,7 @@ pub async fn run(
     unlock_after_install: bool,
     subset_nodes: Option<Vec<&str>>,
     initial_password: Option<&str>,
+    provisioner_type: Option<&ProvisionerType>,
 ) -> NaviResult<()> {
     // Determine which nodes to process. If subset_nodes is provided, use it, otherwise use all targets.
     // However, we still filter by the provisioner in the caller usually, but here we just iterate
@@ -152,6 +154,20 @@ pub async fn run(
                 if let Some(password) = initial_password {
                     na_cmd.env("SSHPASS", password);
                     na_cmd.arg("--env-password");
+                }
+
+                // Resolve --copy-host-keys: Auto enables it for bare-metal
+                // provisioners where the target won't have host keys yet
+                let should_copy_host_keys = match &na_config.copy_host_keys {
+                    CopyHostKeys::Always => true,
+                    CopyHostKeys::Never => false,
+                    CopyHostKeys::Auto => {
+                        provisioner_type == Some(&ProvisionerType::BareMetal)
+                    }
+                };
+                if should_copy_host_keys {
+                    tracing::info!("Copying host keys from installer to target system");
+                    na_cmd.arg("--copy-host-keys");
                 }
 
                 if na_config.download_kexec_locally {


### PR DESCRIPTION
Introduces the `copyHostKeys` configuration option to control the
behavior of copying SSH host keys from the installer to the target
system.

- Added `CopyHostKeys` enum with `Auto`, `Always`, and `Never` variants.
- Defaults to `Auto`, which automatically enables host key copying
  specifically for `BareMetal` provisioners.
- Updated `nixos-anywhere` command execution to pass the `--copy-host-
  keys` flag based on the resolved configuration.
- Updated command callers (`install`, `provision`) to propagate the
  provisioner type required for the `Auto` logic.
